### PR TITLE
fix: error log "ImportError: No module named 'werkzeug.contrib'"

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,3 +1,4 @@
+werkzeug==0.16.0
 flask==1.0
 flask-cors==3.0.0
 sqlalchemy>=1.1.14


### PR DESCRIPTION
exec command `pip3 install -r server/requirements.txt`，the version of `werkzeug` installed by default is `1.0.0`

use the latest version of `werkzeug`(1.0.0 release on 2020-02-07) has error log:
```
Traceback (most recent call last):
  File "server/atm_server/server.py", line 16, in <module>
    from atm_server import SERVER_ROOT, db
  File "server/atm_server/__init__.py", line 5, in <module>
    from atm_server.cli import cli
  File "server/atm_server/cli.py", line 5, in <module>
    from atm_server.server import create_app
  File "server/atm_server/server.py", line 18, in <module>
    from atm_server.api import api
  File "server/atm_server/api.py", line 20, in <module>
    from atm_server.atm_helper import start_worker, stop_worker, work, get_datarun_steps_info, new_datarun, \
  File "server/atm_server/atm_helper/__init__.py", line 2, in <module>
    from .worker import *
  File "server/atm_server/atm_helper/worker.py", line 21, in <module>
    from atm_server.cache import get_cache
  File "server/atm_server/cache.py", line 7, in <module>
    from werkzeug.contrib.cache import SimpleCache, FileSystemCache
ImportError: No module named 'werkzeug.contrib'
```